### PR TITLE
Added a donation page

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -14772,6 +14772,11 @@
         "react-transition-group": "^2.5.0"
       }
     },
+    "react-sticky-footer": {
+      "version": "0.1.0-rc3",
+      "resolved": "https://registry.npmjs.org/react-sticky-footer/-/react-sticky-footer-0.1.0-rc3.tgz",
+      "integrity": "sha512-FKXTCQxLoRhSC0ReEbpE52jqzMcLSYcSJjPQrx8spDGBDp3IWiyo7c1Slibsut4UmHLWG6UUA1sUCDmSAFU43Q=="
+    },
     "react-transition-group": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",

--- a/website/package.json
+++ b/website/package.json
@@ -31,6 +31,7 @@
     "react-scripts": "3.4.0",
     "react-select": "^3.0.8",
     "recharts": "^2.0.0-beta.4",
+    "react-sticky-footer": "~0.1.0-rc3",
     "short-number": "^1.0.7",
     "superagent": "^5.2.2",
     "tsutils": "^3.17.1",

--- a/website/src/App.js
+++ b/website/src/App.js
@@ -14,6 +14,8 @@ import { GraphUSHospitalization, GraphStateHospitalization } from './GraphHospit
 import { CountyHospitalsWidget } from "./Hospitals"
 import { fetchCounty } from "./GeoLocation"
 import { logger, firebase } from "./AppModule"
+import DonationPage from './DonationPage.js';
+import {getDefaultCounty, CookieGetLastCounty} from './DefaultGeoData.js';
 
 const states = require('us-state-codes');
 const Cookies = require("js-cookie");
@@ -126,21 +128,11 @@ const MainApp = withRouter((props) => {
         <Route exact path='/county/:state/:county' render={(props) => <CountyWidget {...props} state={state} county={county} />} />
         <Route exact path='/state/:state' render={(props) => <StateWidget {...props} state={state} county={county} />} />
         <Route exact path='/US' render={(props) => <EntireUSWidget {...props} state={state} county={county} />} />
+        <Route exact path='/donate' render={(props) => <DonationPage {...props} />} />
       </Switch>
     </div>
   );
 });
-
-function getDefaultCounty() {
-  let county_info = CookieGetLastCounty();
-  if (county_info) {
-    return county_info;
-  }
-  return {
-    county: "Santa Clara",
-    state: "CA",
-  }
-}
 
 const EntireUSWidget = withHeader((props) => {
   const default_county_info = getDefaultCounty();
@@ -185,11 +177,6 @@ function CookieSetLastCounty(state, county) {
   Cookies.set("LastCounty", county_info, {
     expires: 7  // 7 day, people are not supposed to be moving anyways
   });
-}
-
-function CookieGetLastCounty() {
-  let county_info = Cookies.getJSON("LastCounty");
-  return county_info;
 }
 
 const CountyWidget = withHeader((props) => {

--- a/website/src/DefaultGeoData.js
+++ b/website/src/DefaultGeoData.js
@@ -1,0 +1,22 @@
+const Cookies = require("js-cookie");
+
+function getDefaultCounty() {
+  const county_info = CookieGetLastCounty();
+  if (county_info) {
+    return county_info;
+  }
+  return {
+    county: "Santa Clara",
+    state: "CA",
+  }
+};
+
+function CookieGetLastCounty() {
+  let county_info = Cookies.getJSON("LastCounty");
+  return county_info;
+}
+
+export {
+  getDefaultCounty,
+  CookieGetLastCounty,
+}; 

--- a/website/src/DonationPage.js
+++ b/website/src/DonationPage.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import { Switch, Route, withRouter, Link} from 'react-router-dom'
+import { BrowserRouter } from 'react-router-dom';
+import { countyModuleInit } from "./USCountyInfo.js";
+import * as USCounty from "./USCountyInfo.js";
+import { Splash } from './Splash.js';
+import { NearbyCounties, CountiesForStateWidget, AllStatesListWidget } from "./CountyListRender.js"
+import { BasicGraphNewCases } from "./GraphNewCases.js"
+import { GraphUSTesting, GraphStateTesting } from "./GraphTestingEffort"
+import { withHeader } from "./Header.js"
+import { MyTabs } from "./MyTabs.js"
+import { USInfoTopWidget } from './USInfoTopWidget.js'
+import { GraphUSHospitalization, GraphStateHospitalization } from './GraphHospitalization.js'
+import { CountyHospitalsWidget } from "./Hospitals"
+import StickyFooter from 'react-sticky-footer';
+import {getDefaultCounty} from './DefaultGeoData.js';
+
+const Cookies = require("js-cookie");
+
+const useStyles = makeStyles(theme => ({
+    container: {
+      margin: 25,
+    },
+    title: {
+        display: 'flex',
+        color: '#FFFFFF',
+        background: '#00aeef',
+        borderRadius: 5,
+        padding: 25,
+        fontSize: "2em",
+        justifyContent: "center",
+    },
+    description: {
+      padding: 10,
+    },
+    fbButton: {
+      color: "white",
+      backgroundColor: "rgb(24, 119, 242)",
+    },
+    gfmButton: {
+      color: "white",
+      backgroundColor: "#00b964",
+    },
+    button: {
+      padding: "1em 1.5em",
+      textDecoration: "none",
+      display: "flex",
+      justifyContent: "center",
+      borderRadius: 5,
+      fontSize: "15px",
+      fontWeight: 600,
+      margin: 10,
+    },
+}));
+
+
+
+const DontationPage = withHeader((props) => {
+  const classes = useStyles();
+  const donateHeader = <div className={classes.title}> Donations </div>;
+  // TODO find a better wording 
+  const description = <div className={classes.description}> 
+    <div>
+      If you find this website useful, please consider donating to keep the service running. 
+    </div>
+    <div>
+      We really appreciate your support. 
+    </div>
+  </div>; 
+  const donationMethods = <div> 
+    <div> 
+      <a className={`${classes.button} ${classes.fbButton}`} target="_blank" href="https://www.facebook.com/donate/1564752357011737/"> 
+        Donate on Facebook 
+      </a>
+      <a className={`${classes.button} ${classes.gfmButton}`} target="_blank" href="https://www.gofundme.com/f/frontlinerespondersfund">
+        Donate on GoFundMe
+      </a>
+    </div>
+    <div>
+    </div>
+  </div>;
+
+  const {casesData} = props;
+  const defaultCountyInfo = getDefaultCounty();
+  return <>
+    <USInfoTopWidget
+        casesData={casesData}
+        county={defaultCountyInfo.county}
+        state={defaultCountyInfo.state}
+      />
+    <div className={classes.container}> 
+      {description}
+      {donationMethods}
+    </div>
+  </>
+});
+
+
+export default DontationPage;

--- a/website/src/Header.js
+++ b/website/src/Header.js
@@ -4,6 +4,9 @@ import Select from 'react-select';
 import Disqus from "disqus-react"
 import Typography from '@material-ui/core/Typography'
 import { makeStyles } from '@material-ui/core/styles';
+import StickyFooter from 'react-sticky-footer';
+import Button from '@material-ui/core/Button';
+
 
 function browseTo(history, state, county) {
     history.push(
@@ -158,7 +161,29 @@ const withHeader = (comp, props) => {
 
             {component}
             {footer}
-        </header >
+
+            {/* TODO Comment out the following section until the donation pages are setup */}
+            <StickyFooter
+                bottomThreshold={0}
+                normalStyles={{
+                    display: "none",
+                }}
+                stickyStyles={{
+                    backgroundColor: "rgba(255,255,255,.9)",
+                    width: "100%",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    padding: 2,
+                }}
+            >   
+                <Button color="link"> Share </Button> 
+                <Button color="link" onClick={() => {
+                    const {history} = props;
+                    history.push("/donate", history.search);
+                }}> Support Us </Button>    
+            </StickyFooter>
+        </header>
 
         return header;
     }

--- a/website/src/USCountyInfo.js
+++ b/website/src/USCountyInfo.js
@@ -177,71 +177,13 @@ const USState_Population =
     "WY": 567025
 }
 
-const USState_Full_Name =
-{
-    "AK": "Alaska",
-    "AL": "Alabama",
-    "AR": "Arkansas",
-    "AZ": "Arizona",
-    "CA": "California",
-    "CO": "Colorado",
-    "CT": "Connecticut",
-    "DC": "District of Columbia",
-    "DE": "Delaware",
-    "FL": "Florida",
-    "GA": "Georgia",
-    "HI": "Hawaii",
-    "IA": "Iowa",
-    "ID": "Idaho",
-    "IL": "Illinois",
-    "IN": "Indiana",
-    "KS": "Kansas",
-    "KY": "Kentucky",
-    "LA": "Louisiana",
-    "MA": "Massachusetts",
-    "MD": "Maryland",
-    "ME": "Maine",
-    "MH": "Marshall Islands",
-    "MI": "Michigan",
-    "MN": "Minnesota",
-    "MO": "Missouri",
-    "MS": "Mississippi",
-    "MT": "Montana",
-    "NC": "North Carolina",
-    "ND": "North Dakota",
-    "NE": "Nebraska",
-    "NH": "New Hampshire",
-    "NJ": "New Jersey",
-    "NM": "New Mexico",
-    "NV": "Nevada",
-    // Added "state" to avoid confusion
-    "NY": "New York (State)",
-    "OH": "Ohio",
-    "OK": "Oklahoma",
-    "OR": "Oregon",
-    "PA": "Pennsylvania",
-    "PR": "Puerto Rico",
-    "RI": "Rhode Island",
-    "SC": "South Carolina",
-    "SD": "South Dakota",
-    "TN": "Tennessee",
-    "TX": "Texas",
-    "UT": "Utah",
-    "VA": "Virginia",
-    "VT": "Vermont",
-    "WA": "Washington",
-    "WI": "Wisconsin",
-    "WV": "West Virginia",
-    "WY": "Wyoming",
-}
-
 function getAllStatesSummary() {
     let state_sum = Object.keys(USState_Population).map(state => casesForStateSummary(state));
     return state_sum.map(s => {
 
         return {
             state: s.state,
-            full_name: USState_Full_Name[s.state],
+            full_name: states.getStateNameByStateCode(s.state),
             confirmed: s.confirmed,
             newcases: s.newcases,
             newpercent: s.newcases / (s.confirmed - s.newcases),


### PR DESCRIPTION
This adds a new route that is the donation page. It currently has two stub url that redirects to other fundraiser pages. We'll need to create our own before this can be launched. 

![image](https://user-images.githubusercontent.com/435537/77835997-720b1b00-710f-11ea-8eba-2a41241ec3fc.png)


The entry point to the donation page is the sticky footer that says "share" and "support us". 
![image](https://user-images.githubusercontent.com/435537/77836009-9666f780-710f-11ea-87e3-0868f1f9b1bd.png)

**Caveat**. The merge created an intermediate revision which I don't really need. Aside from ugly revision tree, it shouldn't have any other consequence when it's merged to master. 

**Next steps**
1. Wilson can you please create the FB fundraiser and goFundMe page before this is landed? 
2. Add funnel logging to track the conversions. 


