### PR TITLE
Add US death and recovery number to top widget

### DIFF
--- a/website/src/USCountyInfo.js
+++ b/website/src/USCountyInfo.js
@@ -400,21 +400,31 @@ function casesForStateSummary(state_short_name) {
         confirmed: confirmed,
         newcases: newcases,
         death: state.Summary.LastDeath,
+        deathNew: state.Summary.LastDeathNew,
         newpercent: ((newcases / (confirmed - newcases)) * 100).toFixed(0),
         stayHomeOrder: state.Summary.StayHomeOrder,
         daysToDouble: state.Summary.DaysToDouble,
         daysToDoubleDeath: state.Summary.DaysToDoubleDeath,
         lastRecovered: state.Summary.LastRecovered,
+        lastRecoveredNew: state.Summary.LastRecoveredNew,
     }
 }
 
 function casesForUSSummary() {
     const confirmed = AllData.Summary.LastConfirmed;
     const newcases = AllData.Summary.LastConfirmedNew;
+    const deaths = AllData.Summary.LastDeath;
+    const deathsNew = AllData.Summary.LastDeathNew;
+    const recovered = AllData.Summary.LastRecovered;
+    const recoveredNew = AllData.Summary.LastRecoveredNew;
     const generatedTime = (new Date(AllData.Summary.generated)).toString();
     return {
         confirmed: confirmed,
         newcases: newcases,
+        deaths: deaths,
+        deathsNew: deathsNew,
+        recovered: newcases,
+        recoveredNew: recoveredNew,
         newpercent: ((newcases / (confirmed - newcases)) * 100).toFixed(0),
         generatedTime: generatedTime,
     }
@@ -472,7 +482,7 @@ function getAllProperCountyDataForUS() {
 
 /**
  * Returns data for all counties in given state found in AllData excluding data for Summary, unallocated, etc.
- * @param {*} statekey 
+ * @param {*} statekey
  */
 function getAllProperCountyDataForState(statekey) {
     const stateData = AllData[statekey];
@@ -481,7 +491,7 @@ function getAllProperCountyDataForState(statekey) {
 
 /**
  * Returns keys for all counties in a given state found in AllData excluding data for Summary, unallocated, etc.
- * @param {*} statekey 
+ * @param {*} statekey
  */
 function getAllProperCountyKeysForState(statekey) {
     const stateData = AllData[statekey];
@@ -496,7 +506,7 @@ function getAllProperStateKeys() {
 }
 
 /**
- * Returns the metro keys used in AllData 
+ * Returns the metro keys used in AllData
  */
 function getAllMetroKeys() {
     return Object.keys(AllData.Metros);
@@ -553,7 +563,7 @@ export {
     getMetroDataForGrapth,
     countyDataForMetro,
 
-    // 
+    //
     casesForCountySummary, // check
     casesForStateSummary, // check
     casesForUSSummary, // check

--- a/website/src/USInfoTopWidget.js
+++ b/website/src/USInfoTopWidget.js
@@ -85,11 +85,17 @@ const useStyles = makeStyles(theme => ({
 
 const USInfoTopWidget = withRouter((props) => {
     const [showBeds, setShowBedsOnScroll] = React.useState(true)
+    const [showDeaths, setShowDeaths] = React.useState(true)
+    const [showRecovered, setShowRecovered] = React.useState(true)
     if (isMobile) {
         useScrollPosition(({ prevPos, currPos }) => {
             const isShow = currPos.y > -100;
-            if (isShow !== showBeds) setShowBedsOnScroll(isShow)
-        }, [showBeds]);
+            if (isShow !== showBeds) {
+                setShowBedsOnScroll(isShow)
+                setShowDeaths(isShow)
+                setShowRecovered(isShow)
+            }
+        }, [showBeds, showDeaths, showRecovered]);
     }
 
     const classes = useStyles();
@@ -149,21 +155,35 @@ const USInfoTopWidget = withRouter((props) => {
             <Tag title={state_title}
                 confirmed={state_summary.confirmed}
                 newcases={state_summary.newcases}
+                deaths={state_summary.death}
+                deathsNew={state_summary.deathNew}
+                recovered={state_summary.lastRecovered}
+                recoveredNew={state_summary.lastRecoveredNew}
                 hospitals={state_hospitals.hospitals}
                 beds={state_hospitals.beds}
                 selected={props.selectedTab === "state"}
                 to={reverse(routes.state, { state })}
                 showBeds={showBeds}
+                // showRecovered={showRecovered}
+                // showDeaths={showDeaths}
+                showRecovered={false}
+                showDeaths={false}
             />
             <Tag
                 title={US_title}
                 confirmed={us_summary.confirmed}
                 newcases={us_summary.newcases}
+                deaths={us_summary.deaths}
+                deathsNew={us_summary.deathsNew}
+                recovered={us_summary.recovered}
+                recoveredNew={us_summary.recoveredNew}
                 hospitals={6146}
                 beds={924107}
                 selected={props.selectedTab === "usa"}
                 to={routes.united_states}
                 showBeds={showBeds}
+                showRecovered={showRecovered}
+                showDeaths={showDeaths}
             />
         </div>
         <div className={classes.timestamp}>
@@ -188,6 +208,33 @@ const Tag = (props) => {
                 <div className={classes.smallTag}>
                     Confirmed </div>
             </section>
+
+            {props.showRecovered &&
+                <section className={classes.tagSection}>
+                    <Typography className={classes.topTag} variant="body2" noWrap >
+                        +{myShortNumber(props.recoveredNew)}
+                    </Typography>
+                    <div className={classes.mainTag}>
+                        {myShortNumber(props.recovered)}</div>
+                    <div className={classes.smallTag}>
+                        Recovered
+                    </div>
+                </section>
+            }
+
+            {props.showDeaths &&
+                <section className={classes.tagSection}>
+                    <Typography className={classes.topTag} variant="body2" noWrap >
+                        +{myShortNumber(props.deathsNew)}
+                    </Typography>
+                    <div className={classes.mainTag}>
+                        {myShortNumber(props.deaths)}</div>
+                    <div className={classes.smallTag}>
+                        Deaths
+                    </div>
+                </section>
+            }
+
             {props.showBeds && <section className={classes.tagSection}>
                 <Typography className={classes.topTag} variant="body2" noWrap >
                     {myShortNumber(props.hospitals)} Hosp.


### PR DESCRIPTION
On iPhone 8:
Top of the page:
<img width="321" alt="image" src="https://user-images.githubusercontent.com/10097700/78419224-83b15e80-75f8-11ea-9aa5-33fce18bb200.png">
Scrolling up:
<img width="319" alt="image" src="https://user-images.githubusercontent.com/10097700/78419229-8ca23000-75f8-11ea-977d-7006986e551f.png">
