### PR TITLE
Support using url to select the active graph/table

### DIFF
--- a/website/src/App.js
+++ b/website/src/App.js
@@ -13,10 +13,11 @@ import { PageMetro } from "./PageMetro"
 import { Page404 } from "./Page404"
 import { reverse } from 'named-urls';
 import routes from "./Routes";
+import history from "./history";
 
 const App = (props) => {
   return <BrowserRouter>
-    <MainApp  {...props} />
+    <MainApp  {...props} history={history} />
   </BrowserRouter>;
 };
 

--- a/website/src/MyTabs.js
+++ b/website/src/MyTabs.js
@@ -63,11 +63,28 @@ const LinkTab = withStyles((theme) => ({
 const MyTabs = (props) => {
     const tabs = props.tabs;
     const labels = props.labels;
-    const startIndex = props.startTab ? props.startTab : 0;
-    const [tabvalue, setTabvalue] = React.useState(startIndex);
+    let selectedTabIdx = 0;
+    if (("history" in props) && ("location" in props.history)) {
+        // e.g. {'graph': 'cases', 'table': 'testing'}
+        let searchParams = new URLSearchParams(props.history.location.search);
+        // e.g. 'testing'
+        let selectedTabName = searchParams.get(props.urlQueryKey);
+        selectedTabIdx = props.urlQueryValues.findIndex(name => name === selectedTabName);
+        if (selectedTabIdx === -1) {
+            // The active tab is not specified in the url query
+            selectedTabIdx = 0;
+        }
+    }
+
+    const [tabvalue, setTabvalue] = React.useState(selectedTabIdx);
 
     const handleChange = (event, newValue) => {
         setTabvalue(newValue);
+        // Change url without reloading the page
+        let searchParams = new URLSearchParams(props.history.location.search);
+        searchParams.set(props.urlQueryKey, props.urlQueryValues[newValue]);
+        props.history.location.search = searchParams.toString();
+        props.history.push(props.history.location)
     }
     let c = 0;
     let labelcomp = labels.map(l =>

--- a/website/src/PageCounty.js
+++ b/website/src/PageCounty.js
@@ -39,7 +39,10 @@ const GraphSectionCounty = withRouter((props) => {
     ]
     let graphlistSection = <MyTabs
         labels={["Cases", `${state_title} Testing`]}
+        urlQueryKey="graph"
+        urlQueryValues={['cases', 'testing']}
         tabs={tabs}
+        history={props.history}
     />;
     return graphlistSection;
 });
@@ -77,7 +80,10 @@ const PageCounty = withHeader((props) => {
             />
             <MyTabs
                 labels={["Nearby", "Hospitals"]}
+                urlQueryKey="table"
+                urlQueryValues={['nearby', 'hospitals']}
                 tabs={tabs}
+                history={props.history}
             />
         </>
     );

--- a/website/src/PageMetro.js
+++ b/website/src/PageMetro.js
@@ -19,7 +19,10 @@ const GraphSectionMetro = withRouter((props) => {
     ]
     let graphlistSection = <MyTabs
         labels={["Cases"]}
+        urlQueryKey="graph"
+        urlQueryValues={['cases']}
         tabs={tabs}
+        history={props.history}
     />;
     return graphlistSection;
 });
@@ -55,7 +58,10 @@ const PageMetro = withHeader((props) => {
             />
             <MyTabs
                 labels={[metro_info.Name]}
+                urlQueryKey="table"
+                urlQueryValues={['cases']}
                 tabs={tabs}
+                history={props.history}
             />
         </>
     );

--- a/website/src/PageState.js
+++ b/website/src/PageState.js
@@ -58,7 +58,10 @@ const GraphSectionState = withRouter((props) => {
             `${state} State Recovery`,
             `${state} Test`,
             "Hospitalization"]}
+        urlQueryKey="graph"
+        urlQueryValues={['cases', 'recovery', 'testing', 'hospitalization']}
         tabs={tabs}
+        history={props.history}
     />;
     return graphlistSection;
 });
@@ -101,7 +104,10 @@ const PageState = withHeader((props) => {
             />
             <MyTabs
                 labels={[`Counties of ${states.getStateNameByStateCode(state)} `, "Per Capita"]}
+                urlQueryKey="table"
+                urlQueryValues={['cases', 'capita']}
                 tabs={tabs}
+                history={props.history}
             />
         </>);
 });

--- a/website/src/PageUS.js
+++ b/website/src/PageUS.js
@@ -23,7 +23,6 @@ const GraphTabIndex = {
 
 const GraphSectionUS = withRouter((props) => {
     let graphdata = USCounty.getUSDataForGrapth();
-    let tabIndex = GraphTabIndex[props.match.url];
 
     const tabs = [
         <BasicGraphNewCases data={graphdata} logScale={false} />,
@@ -33,8 +32,10 @@ const GraphSectionUS = withRouter((props) => {
     ]
     let graphlistSection = <MyTabs
         labels={["Cases", `Recovery & Death`, `Testing`, "Hospitalization"]}
+        urlQueryKey="graph"
+        urlQueryValues={['cases', 'recovery_death', 'testing', 'hospitalization']}
         tabs={tabs}
-        startTab={tabIndex}
+        history={props.history}
     />;
     return graphlistSection;
 });
@@ -63,7 +64,10 @@ const PageUS = withHeader((props) => {
             <GraphSectionUS />
             <MyTabs
                 labels={["States of USA", "Testing", "Capita"]}
+                urlQueryKey="table"
+                urlQueryValues={['cases', 'testing', 'capita']}
                 tabs={tabs}
+                history={props.history}
             />
         </>
     );

--- a/website/src/history.js
+++ b/website/src/history.js
@@ -1,0 +1,3 @@
+import createHistory from "history/createBrowserHistory";
+
+export default createHistory();


### PR DESCRIPTION
For example, if the url is `http://localhost:3000/US?graph=recovery_death&table=testing`, then these will be selected:
- "recovery & death" graph
- "testing" table
<img width="567" alt="image" src="https://user-images.githubusercontent.com/10097700/78463825-9a0df780-7696-11ea-8c7e-ee483c0f853b.png">

This makes it easier for people to share a specific graph/table.