### PR TITLE
Replace Day2x with growth rate in main chart

### DIFF
--- a/website/src/GraphNewCases.js
+++ b/website/src/GraphNewCases.js
@@ -155,13 +155,13 @@ const GraphOptionsMenuProps = {
     },
 };
 
-const daysToDoubleLabelChildren = (options) => {
-    const { x, y, showlog, daysToDouble } = options;
+const trendingLineLabelChildren = (options) => {
+    const { x, y, showlog, dailyGrowthRate } = options;
     return [
         // Placeholder to accomodate label
         <ReferenceArea fillOpacity="0" alwaysShow x1={x} x2={x} y1={y * (showlog ? 4 : 1.1)} y2={y * (showlog ? 4 : 1.1)} key={0} />,
         <ReferenceArea fillOpacity="0" x1={x} x2={x} y1={y} y2={y} key={1}>
-            <Label value={`Double every ${daysToDouble.toFixed(1)} days*`} offset={5} position="insideBottomRight" />
+            <Label value={`Grew by ${(dailyGrowthRate * 100).toFixed(0)}% per day*`} offset={5} position="insideBottomRight" />
         </ReferenceArea>
     ];
 }
@@ -278,14 +278,14 @@ const BasicGraphNewCases = (props) => {
     const daysFromStart = datesToDays(startDate, dates);
     const confirmed = data.map(d => d.confirmed);
     const results = fitExponentialTrendingLine(daysFromStart, confirmed, 10);
-    let daysToDouble = null;
+    let dailyGrowthRate = null;
     let lastTrendingData = null;
     if (results != null) {
         data = data.map((d, idx) => {
             d.trending_line = results.fittedYs[idx];
             return d;
         });
-        daysToDouble = results.daysToDouble;
+        dailyGrowthRate = results.dailyGrowthRate;
         lastTrendingData = data[data.length - 1];
     }
 
@@ -426,10 +426,10 @@ const BasicGraphNewCases = (props) => {
                 {vRefLines}
                 {hRefLines}
 
-                {state.showConfirmed && lastTrendingData != null && daysToDoubleLabelChildren({
+                {state.showConfirmed && lastTrendingData != null && trendingLineLabelChildren({
                     x: lastTrendingData.name,
                     y: lastTrendingData.trending_line,
-                    daysToDouble,
+                    dailyGrowthRate,
                     showlog: state.showlog
                 }
                 )}

--- a/website/src/GraphNewCases.js
+++ b/website/src/GraphNewCases.js
@@ -156,12 +156,12 @@ const GraphOptionsMenuProps = {
 };
 
 const trendingLineLabelChildren = (options) => {
-    const { x, y, showlog, dailyGrowthRate } = options;
+    const { x, y, showlog, dailyGrowthRate, daysToDouble } = options;
     return [
         // Placeholder to accomodate label
         <ReferenceArea fillOpacity="0" alwaysShow x1={x} x2={x} y1={y * (showlog ? 4 : 1.1)} y2={y * (showlog ? 4 : 1.1)} key={0} />,
         <ReferenceArea fillOpacity="0" x1={x} x2={x} y1={y} y2={y} key={1}>
-            <Label value={`Grew by ${(dailyGrowthRate * 100).toFixed(0)}% per day*`} offset={5} position="insideBottomRight" />
+            <Label value={`${daysToDouble.toFixed(0)} days to double (+${(dailyGrowthRate * 100).toFixed(0)}% daily)`} offset={5} position="insideBottomRight" />
         </ReferenceArea>
     ];
 }
@@ -279,6 +279,7 @@ const BasicGraphNewCases = (props) => {
     const confirmed = data.map(d => d.confirmed);
     const results = fitExponentialTrendingLine(daysFromStart, confirmed, 10);
     let dailyGrowthRate = null;
+    let daysToDouble = null;
     let lastTrendingData = null;
     if (results != null) {
         data = data.map((d, idx) => {
@@ -286,6 +287,7 @@ const BasicGraphNewCases = (props) => {
             return d;
         });
         dailyGrowthRate = results.dailyGrowthRate;
+        daysToDouble = results.daysToDouble;
         lastTrendingData = data[data.length - 1];
     }
 
@@ -430,6 +432,7 @@ const BasicGraphNewCases = (props) => {
                     x: lastTrendingData.name,
                     y: lastTrendingData.trending_line,
                     dailyGrowthRate,
+                    daysToDouble,
                     showlog: state.showlog
                 }
                 )}

--- a/website/src/TrendFitting.js
+++ b/website/src/TrendFitting.js
@@ -17,6 +17,7 @@ const fitExponentialTrendingLine = (xs, ys, minY) => {
     }
     return {
         daysToDouble: 1 / results.slope,
+        dailyGrowthRate: Math.exp(Math.log(2) * results.slope) - 1,
         fittedYs: results.fittedYs.map(y => Math.exp(y * Math.log(2)))
     };
 };


### PR DESCRIPTION
Since cases will take a long time to double, switching trending to growth rate will better describe situation.

Verify the math with US total case:

4/10: 508297 (+7.61%)
4/9: 472331 (+8%)
4/8: 437358 (+8.16%)
4/7: 404333

![Screen Shot 2020-04-12 at 2 07 59 PM](https://user-images.githubusercontent.com/3301683/79080000-45d2cb00-7cc7-11ea-8c33-e74bf3e711b3.png)
