### PR TITLE
[Rough draft] Ideas to allow more graphs, power, and simplicity

### DIFF
--- a/website/src/AdvancedGraph.js
+++ b/website/src/AdvancedGraph.js
@@ -1,0 +1,224 @@
+import React from 'react';
+import { fade, makeStyles } from '@material-ui/core/styles';
+import Paper from '@material-ui/core/Paper';
+import ToggleButton from '@material-ui/lab/ToggleButton';
+import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
+import { Area, AreaChart, CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+
+const baseToggleButtonStyles = {
+    height: 'initial',
+    textTransform: 'initial',
+};
+
+const useStyles = makeStyles(theme => ({
+    options: {
+        display: 'flex',
+        flexWrap: 'wrap',
+        marginBottom: '16px',
+        '& > *': {
+            margin: '8px',
+        },
+    },
+    displayOptions: {
+        flexGrow: 1,
+    },
+}));
+
+export const AdvancedGraph = (props) => {
+    const classes = useStyles();
+
+    const displays = new Map([
+        ['line', {
+            label: 'Line',
+            chart: LineChart,
+            series: Line,
+        }],
+        ['area', {
+            label: 'Area',
+            chart: AreaChart,
+            series: Area,
+        }],
+    ]);
+    const [display, setDisplay] = React.useState(displays.keys().next().value);
+
+    const serieses = new Map([
+        ['confirmed', {
+            'label': 'Confirmed',
+            'color': 'orange',
+        }],
+        ['deaths', {
+            'label': 'Deaths',
+            'color': 'red',
+        }],
+        ['hospitalized', {
+            'label': 'Hospitalized',
+            'color': 'purple',
+        }],
+        ['recovered', {
+            'label': 'Recovered',
+            'color': 'green',
+        }],
+        ['tested', {
+            'label': 'Tested',
+            'color': 'gray',
+        }],
+        ['tested-negative', {
+            'label': 'Tested negative',
+            'color': 'blue',
+        }],
+        ['tested-positive', {
+            'label': 'Tested positive',
+            'color': 'pink',
+        }],
+    ]);
+    const [selected, setSelected] = React.useState(() => ['confirmed', 'deaths']);
+
+    return <>
+        <div className={classes.options}>
+            <Display
+                displays={displays}
+                selected={display}
+                onChange={setDisplay}
+                className={classes.displayOptions} />
+            <Legend
+                serieses={serieses}
+                selected={selected}
+                onChange={setSelected} />
+        </div>
+        <Chart
+            display={displays.get(display)}
+            serieses={
+                selected.map(
+                    key => ({
+                        key,
+                        color: serieses.get(key).color,
+                    }))} />
+    </>;
+};
+
+const useDisplayStyles = makeStyles(theme => ({
+    option: {
+        ...baseToggleButtonStyles,
+    },
+}));
+
+const Display = (props) => {
+    const classes = useDisplayStyles();
+
+    return (
+        <ToggleButtonGroup
+                exclusive
+                value={props.selected}
+                onChange={(event, desired) => props.onChange(desired)}
+                className={props.className}>
+            {[...props.displays.entries()].map(([key, data]) => 
+                <ToggleButton key={key} value={key} className={classes.option}>
+                    {data.label}
+                </ToggleButton>
+            )}
+        </ToggleButtonGroup>
+    );
+};
+
+const useLegendStyles = makeStyles(theme => ({
+    serieses: {
+        border: `1px solid ${fade(theme.palette.action.active, 0.12)}`,
+        display: 'flex',
+        flexWrap: 'wrap',
+    },
+    series: {
+        border: 'none',
+        color: fade(theme.palette.action.active, 0.12),
+        '&.selected': {
+            backgroundColor: 'initial',
+            color: fade(theme.palette.action.active, 0.8),
+        },
+        ...baseToggleButtonStyles,
+    },
+    icon: {
+      fontSize: '2em',
+    },
+}));
+
+const Legend = (props) => {
+    const classes = useLegendStyles();
+
+    return (
+        <ToggleButtonGroup
+                value={props.selected}
+                onChange={(event, desired) => props.onChange(desired)}
+                className={classes.serieses}>
+            {[...props.serieses.entries()].map(([id, series]) =>
+                <ToggleButton
+                    key={id}
+                    value={id}
+                    classes={{root: classes.series, selected: 'selected'}}>
+                    <span
+                        className={series.icon}
+                        style={
+                            props.selected.includes(id)
+                                ? {color: series.color}
+                                : {}}>
+                      —
+                    </span>
+                    {series.label}
+                </ToggleButton>
+            )}
+        </ToggleButtonGroup>
+    );
+};
+
+const Chart = (props) => {
+    const data = [
+        {
+          'date': '4/1',
+          'confirmed': 12,
+          'hospitalized': 2,
+          'deaths': 1,
+        },
+        {
+          'date': '4/2',
+          'confirmed': 24,
+          'hospitalized': 4,
+          'deaths': 2,
+        },
+        {
+          'date': '4/3',
+          'confirmed': 48,
+          'hospitalized': 8,
+          'deaths': 4,
+        },
+        {
+          'date': '4/4',
+          'confirmed': 96,
+          'hospitalized': 16,
+          'deaths': 8,
+        },
+    ];
+
+    const ChosenChart = props.display.chart;
+    const ChosenSeries = props.display.series;
+
+    return (
+        <ResponsiveContainer height={300}>
+            <ChosenChart data={data} width={500} height={300}>
+                <Tooltip />
+                <XAxis dataKey="date" />
+                <YAxis />
+                <CartesianGrid stroke="#d5d5d5" strokeDasharray="5 5" />
+
+                {props.serieses && props.serieses.map(series =>
+                    <ChosenSeries
+                        type="monotone"
+                        key={series.key}
+                        dataKey={series.key}
+                        isAnimationActive={false}
+                        fill={series.color}
+                        stroke={series.color}
+                        dot={false}
+                        strokeWidth={2} />
+                )}
+            </ChosenChart>
+        </ResponsiveContainer>
+    );
+};

--- a/website/src/CovidUI.js
+++ b/website/src/CovidUI.js
@@ -1,22 +1,21 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
+import Divider from '@material-ui/core/Divider';
 
 const useStyles = makeStyles(theme => ({
     sectionHeader: {
-        "border-left": ".1rem solid #f50057",
-        "border-bottom": ".1rem solid #f3f3f3",
-        margin: 3,
-        padding: 3,
+      display: 'flex',
+      justifyContent: 'center',
     }
 }));
 
 const SectionHeader = (props) => {
     const classes = useStyles();
-    return (
+    return <>
         <div className={classes.sectionHeader}>
             {props.children}
         </div>
-    );
+    </>;
 }
 
 

--- a/website/src/PageState.js
+++ b/website/src/PageState.js
@@ -2,7 +2,11 @@ import React, { useContext } from 'react';
 import { CountryContext } from "./CountryContext";
 import * as Util from "./Util"
 import { GraphStateTesting } from "./GraphTestingEffort"
+import { makeStyles } from '@material-ui/core/styles';
 import { withHeader } from "./Header.js"
+import Tab from '@material-ui/core/Tab';
+import Tabs from '@material-ui/core/Tabs';
+import Paper from '@material-ui/core/Paper';
 import { MyTabs } from "./MyTabs.js"
 import { USInfoTopWidget, StateSummarySection } from './USInfoTopWidget.js'
 import { withRouter } from 'react-router-dom'
@@ -15,8 +19,18 @@ import { Redirect } from 'react-router-dom'
 import { MapState } from "./Map";
 import { GraphDaysToDoubleOverTime } from "./GraphDaysToDoubleOverTime"
 import { GraphDeathProjectionState, GraphAllBedProjectionState } from "./GraphDeathProjection.js"
+import { AdvancedGraph } from './AdvancedGraph';
 
 const moment = require("moment");
+
+const useStyles = makeStyles(theme => ({
+    content: {
+      margin: '0 8px 16px 8px',
+    },
+    tabContent: {
+        padding: '8px',
+    }
+}));
 
 const StateGraphCaveat = (props) => {
     return <div>
@@ -37,44 +51,89 @@ const GraphSectionState = withRouter((props) => {
     let stateSummary = state.summary();
     let stayHomeOrder = state.stayHomeOrder();
 
-    const tabs = [
-        <BasicGraphNewCases
-            data={graphdata}
-            logScale={true}
-            vRefLines={
-                stayHomeOrder ?
-                    [{
-                        date: moment(stayHomeOrder.StartDate
-                        ).format("M/D"),
-                        label: "Stay-At-Home Order",
-                    }] : []
-            } />,
-        <GraphDaysToDoubleOverTime data={props.state.daysToDoubleTimeSeries()} />,
-        <GraphDeathProjectionState state={state} />,
-        // <GraphAllBedProjectionState state={state} />,
-        <StateGraphCaveat stateSummary={stateSummary} data={graphdata} logScale={false} />,
-        <MapState state={state} />,
-        <GraphStateTesting state={state} />,
-        <GraphStateHospitalization state={state} />,
-    ]
-    let graphlistSection = <MyTabs
-        labels={["Cases",
-            "Days to 2x",
-            "Peak Death",
-            // "Peak Hospitalization",
-            "Recovery",
-            "Map",
-            "Tests",
-            "Hospitalization",
-        ]}
-        urlQueryKey="graph"
-        urlQueryValues={['cases', 'days2x', 'peakdeath',
-            // 'peakhospital', 
-            'recovery', 'map', 'testing', 'hospitalization']}
-        tabs={tabs}
-        history={props.history}
-    />;
-    return graphlistSection;
+    const classes = useStyles();
+
+    const tabs = new Map([
+            ['glance', {
+                'label': `At a glance`,
+                'content': <>
+                      <StateSummarySection state={state} />
+                      <BasicGraphNewCases
+                          data={graphdata}
+                          logScale={true}
+                          vRefLines={
+                              stayHomeOrder ?
+                                  [{
+                                      date: moment(stayHomeOrder.StartDate
+                                      ).format("M/D"),
+                                      label: "Stay-At-Home Order",
+                                  }] : []
+                          } />
+                </>,
+            }],
+            ['detailed', {
+                'label': "Detailed",
+                'content': <AdvancedGraph target={state} />,
+            }],
+            ['doubling', {
+                'label': "Doubling",
+                'content': <GraphDaysToDoubleOverTime data={state.daysToDoubleTimeSeries()} />,
+            }],
+            ['children', {
+                'label': "Counties",
+                'content': <CountiesForStateWidget state={state} />,
+            }],
+            ['map', {
+                'label': "Map",
+                'content': <MapState state={state} />,
+            }],
+    ]);
+    const headings = [...tabs.keys()];
+
+    const [viewing, setViewing] = React.useState(headings[0]);
+    const switchTo = (e, index) => setViewing(headings[index]);
+    return (
+        <div className={classes.content}>
+            <Typography variant="h2">{state.name}</Typography>
+            <Tabs
+                value={headings.indexOf(viewing)}
+                onChange={switchTo}>
+                {[...tabs.values()].map((tab, i) =>
+                    <Tab label={tab.label} key={i} />
+                )}
+            </Tabs>
+            <Paper className={classes.tabContent}>
+              {tabs.get(viewing).content}
+            </Paper>
+        </div>
+    );
+
+    //const tabs = [
+    //    <GraphDaysToDoubleOverTime data={props.state.daysToDoubleTimeSeries()} />,
+    //    <GraphDeathProjectionState state={state} />,
+    //    // <GraphAllBedProjectionState state={state} />,
+    //    <StateGraphCaveat stateSummary={stateSummary} data={graphdata} logScale={false} />,
+    //    <GraphStateTesting state={state} />,
+    //    <GraphStateHospitalization state={state} />,
+    //]
+    //let graphlistSection = <MyTabs
+    //    labels={["Cases",
+    //        "Days to 2x",
+    //        "Peak Death",
+    //        // "Peak Hospitalization",
+    //        "Recovery",
+    //        "Map",
+    //        "Tests",
+    //        "Hospitalization",
+    //    ]}
+    //    urlQueryKey="graph"
+    //    urlQueryValues={['cases', 'days2x', 'peakdeath',
+    //        // 'peakhospital', 
+    //        'recovery', 'map', 'testing', 'hospitalization']}
+    //    tabs={tabs}
+    //    history={props.history}
+    ///>;
+    //return graphlistSection;
 });
 
 const PageState = withHeader((props) => {
@@ -89,7 +148,6 @@ const PageState = withHeader((props) => {
     Util.CookieSetLastCounty(state.twoLetterName, county ? county.name : null);
 
     const tabs = [
-        <CountiesForStateWidget state={state} />,
         <ListStateCountiesCapita state={state} />,
     ];
 
@@ -102,15 +160,7 @@ const PageState = withHeader((props) => {
                 country={country}
                 selectedTab={"state"}
             />
-            <StateSummarySection state={state} />
             <GraphSectionState state={state} />
-            <MyTabs
-                labels={[`Counties of ${state.name} `, "Per Capita"]}
-                urlQueryKey="table"
-                urlQueryValues={['cases', 'capita']}
-                tabs={tabs}
-                history={props.history}
-            />
         </>);
 });
 

--- a/website/src/Theme.js
+++ b/website/src/Theme.js
@@ -1,6 +1,11 @@
 import { createMuiTheme } from '@material-ui/core/styles';
 
 export const compactTheme = createMuiTheme({
+    palette: {
+        secondary: {
+            main: '#00aeef',
+        },
+    },
     overrides: {
         MuiTableCell: {
             sizeSmall: {  //This can be referred from Material UI API documentation.

--- a/website/src/USInfoTopWidget.js
+++ b/website/src/USInfoTopWidget.js
@@ -3,6 +3,7 @@ import { makeStyles, useTheme } from '@material-ui/core/styles';
 import { myShortNumber } from "./Util.js";
 import { withRouter } from 'react-router-dom'
 import { Typography } from '@material-ui/core';
+import Paper from '@material-ui/core/Paper';
 import { Link } from 'react-router-dom';
 import { SectionHeader } from "./CovidUI"
 import useMediaQuery from '@material-ui/core/useMediaQuery';
@@ -20,6 +21,7 @@ const useStyles = makeStyles(theme => ({
         justifyContent: "space-between",
         display: "flex",
         flexWrap: "wrap",
+        margin: '16px 0',
     },
     tagContainerNoBeds: {
         flexWrap: "nowrap",
@@ -94,11 +96,23 @@ const useStyles = makeStyles(theme => ({
         padding: theme.spacing(0, 1),
         textAlign: "left",
     },
-    sectionHeader: {
-        "border-left": ".1rem solid #f50057",
-        margin: 3,
-        padding: 3,
-    }
+    summary: {
+        alignItems: 'center',
+        display: 'flex',
+        flexWrap: 'wrap',
+        padding: '12px',
+        margin: '16px 8px',
+    },
+    summaryLabel: {
+        width: '100%',
+    },
+    summaryTotal: {
+        flexGrow: 1,
+        fontSize: '2em',
+    },
+    summaryChange: {
+        flexGrow: 1,
+    },
 }));
 
 const USSummarySection = withRouter((props) => {
@@ -311,61 +325,41 @@ const USInfoTopWidget = withRouter((props) => {
 
 const ShortSummary = (props) => {
     const classes = useStyles();
+
+    const pop = (label, total, change) =>
+        <Paper className={classes.summary}>
+            <div className={classes.summaryLabel}>
+                {label}
+            </div>
+            <div className={classes.summaryTotal}>
+                {total}
+            </div>
+            <div className={classes.summaryChange}>
+                {change}
+            </div>
+        </Paper>;
+
     return (
         <SectionHeader>
-            <Typography variant="h6" noWrap >
-                {props.title}
-            </Typography>
-            <div className={`${classes.rowSummary} ${props.showBeds ? '' : classes.rowNoBeds}`} >
-                <div></div>
-                <section className={classes.tagSection}>
-                    <div className={classes.topTag}>
-                        +{myShortNumber(props.newcases)}
-                    </div>
-                    <div className={classes.mainTag}>
-                        {myShortNumber(props.confirmed)} </div>
-                    <div className={classes.smallTag}>
-                        Confirmed </div>
-                </section>
-
-                {props.showRecovered &&
-                    <section className={classes.tagSection}>
-                        <Typography className={classes.topTag} variant="body2" noWrap >
-                            +{myShortNumber(props.recoveredNew)}
-                        </Typography>
-                        <div className={classes.mainTag}>
-                            {myShortNumber(props.recovered)}</div>
-                        <div className={classes.smallTag}>
-                            Recovered
-                    </div>
-                    </section>
-                }
-
-                {props.showDeaths &&
-                    <section className={classes.tagSection}>
-                        <Typography className={classes.topTag} variant="body2" noWrap >
-                            +{myShortNumber(props.deathsNew)}
-                        </Typography>
-                        <div className={classes.mainTag}>
-                            {myShortNumber(props.deaths)}</div>
-                        <div className={classes.smallTag}>
-                            Deaths
-                    </div>
-                    </section>
-                }
-
-                {props.showBeds && <section className={classes.tagSection}>
-                    <Typography className={classes.topTag} variant="body2" noWrap >
-                        {myShortNumber(props.hospitals)} Hosp.
-          </Typography>
-                    <div className={classes.mainTag}>
-                        {myShortNumber(props.beds)}</div>
-                    <div className={classes.smallTag}>
-                        Beds
-                    </div>
-                </section>}
-                <div></div>
-            </div>
+            {pop(
+                'Confirmed',
+                myShortNumber(props.confirmed),
+                `+${myShortNumber(props.newcases)}`)}
+            {props.showRecovered &&
+                pop(
+                    'Recovered',
+                    myShortNumber(props.recovered),
+                    `+${myShortNumber(props.recoveredNew)}`)}
+            {props.showDeaths &&
+                pop(
+                    'Deaths',
+                    myShortNumber(props.deaths),
+                    `+${myShortNumber(props.deathsNew)}`)}
+            {props.showBeds &&
+                pop(
+                    'Hospitalized',
+                    myShortNumber(props.beds),
+                    '')}
         </SectionHeader>
     );
 };


### PR DESCRIPTION
The code here is super rough, I only did this for the states page, etc, but here's some ideas.

* Rather than having [8 graphs showing 9 pieces of data](https://docs.google.com/spreadsheets/d/1dM7CnsNyEuCwF0HtzWIGfK41o-bd52V8FdXjEmMmJ4w/edit?usp=sharing) see if we can collapse to a single "best" view and an advanced view that lets the user make whatever they want to make. I thought doubling had to be a separate graph too, but now I see #75 so that's exciting!
* If the objects in UnitedStates.js all exposed a consistent object, then we could use the same "At a glance"/"Detailed"/"Doubling" views for all of them (I didn't do this yet) and intelligently hide graphs like "Hospitalizations" when the object doesn't have any info on it
* Rather than showing the high level summary on all pages, only show it on the at a glance page. If the user is looking at the additional graphs, they've probably already seen those numbers so may as well not show it
* Rather than showing the area charts as a different graph than the line charts, just let the user pick what they want
* I don't know what to do with log, I think I'll put it to the right of "Line"/"Area" but it makes me sad.
* Adding margin to the state/county/whatever name and making it larger makes the page feel like it can breathe
* Using Paper elements gives depth to the page so it's clearer what options affect what sections
* Tried to make the colors more consistent, that red accent isn't working for me (probably should change it to blue in the map but...)

What do you think?

The original view, just slightly changed
![image](https://user-images.githubusercontent.com/115766/79080611-3c4b6200-7ccb-11ea-833e-06873fbc707a.png)

The detailed tab
![image](https://user-images.githubusercontent.com/115766/79080602-30f83680-7ccb-11ea-8157-e2d2109c9c40.png)

The detailed tab when selecting "area"
![image](https://user-images.githubusercontent.com/115766/79080694-f216b080-7ccb-11ea-9862-bbecf86a917b.png)
