### PR TITLE
Support searching for metros

### DIFF
--- a/website/src/Header.js
+++ b/website/src/Header.js
@@ -167,7 +167,7 @@ const SearchBox = (props) => {
             return {
                 display_name: `${county.name}, ${county.state().name}`,
                 county: county,
-                total: county.totalConfirmed(),
+                total: county.totalConfirmed() + county.newCases(),
             };
         });
     const states = country.allStates().map(
@@ -178,7 +178,15 @@ const SearchBox = (props) => {
                 total: state.totalConfirmed() + state.newCases(),
             }
         });
-    const search_list = counties.concat(states)
+    const metros = country.allMetros().map(
+        metro => {
+            return {
+                display_name: `${metro.name}, ${metro.state().name}`,
+                metro: metro,
+                total: metro.totalConfirmed() + metro.newCases(),
+            }
+        });
+    const search_list = counties.concat(states).concat(metros)
     let search_list_sorted = search_list.sort((a, b) => {
         let x = a.total;
         let y = b.total;
@@ -215,6 +223,8 @@ const SearchBox = (props) => {
                 let route;
                 if (param.value.county) {
                     route = param.value.county.routeTo();
+                } else if (param.value.metro) {
+                    route = param.value.metro.routeTo();
                 } else {
                     route = param.value.state.routeTo();
                 }

--- a/website/src/UnitedStates.js
+++ b/website/src/UnitedStates.js
@@ -91,6 +91,10 @@ export class Country {
     return this.metrosById_.get(id);
   }
 
+  allMetros() {
+    return [...this.metrosById_.values()];
+  }
+
   stateForId(id) {
     return this.statesById_.get(id);
   }
@@ -352,6 +356,18 @@ export class Metro {
     return this.covidRaw_['Summary'];
   }
 
+  totalConfirmed() {
+    if (!this.covidRaw_) {
+      return 0;
+    }
+
+    return this.covidRaw_.Summary.LastConfirmed;
+  }
+
+  newCases() {
+    return this.covidRaw_.Summary.LastConfirmedNew;
+  }
+
   daysToDoubleTimeSeries() {
     let confirmed = getDay2DoubleTimeSeries(
       trimLastDaysData(this.covidRaw_.Summary.Confirmed)
@@ -497,6 +513,14 @@ export class County {
     }
 
     return this.covidRaw_.LastConfirmed;
+  }
+
+  newCases() {
+    if (!this.covidRaw_) {
+      return 0;
+    }
+
+    return this.covidRaw_.LastConfirmedNew;
   }
 
   update(data) {


### PR DESCRIPTION
1. Add metros to the search bar
<img width="217" alt="Screen Shot 2020-04-12 at 10 02 34 PM" src="https://user-images.githubusercontent.com/10097700/79093535-6459b600-7d09-11ea-8e08-8cec123163ab.png">

2. Fix a bug. Right now the number displayed on the search bar is inconsistent between counties and states:
- for states, it is confirmed cases + new cases
- for counties, it is confirmed cases.
This diff makes it also (confirmed cases + new cases) for counties.

