### PR TITLE
Fixed babel-eslint version issue which prevented app start

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",
-    "babel-eslint": "^10.0.3",
+    "babel-eslint": "10.0.3",
     "build-url": "^2.0.0",
     "d3-scale": "^3.2.1",
     "disqus-react": "^1.0.7",


### PR DESCRIPTION
React depends on exactly v10.0.3 of `babel-eslint`

Previously, v10.1.0 was installing and react-scripts start wouldn't launch the app because of the missing dependency.