### PR TITLE
Adding a useStickyState hook, which saves state as cookie

### DIFF
--- a/website/src/Util.js
+++ b/website/src/Util.js
@@ -1,7 +1,8 @@
+import { useState } from 'react'
+
 var shortNumber = require('short-number');
 const Cookies = require("js-cookie");
 const states = require('us-state-codes');
-
 const moment = require("moment");
 
 function myShortNumber(n) {
@@ -135,6 +136,24 @@ function normalize_date(k) {
     return `${m}/${d}/${y}`;
 }
 
+function useStickyState({defaultValue, cookieId, isCookieStale = (c) => false, expiration = null}){
+    let readCookie = Cookies.getJSON(cookieId);
+    if (!readCookie || (isCookieStale(readCookie))) {
+        readCookie = defaultValue;
+    }
+
+    const [state, setState] = useState(readCookie);
+
+    const setStateSticky = (newState) => {
+        Cookies.set(cookieId, newState, {
+          expires: expiration
+        });
+        setState(newState);
+    }
+
+    return [state, setStateSticky];
+}
+
 
 export {
     myShortNumber,
@@ -149,5 +168,6 @@ export {
     normalize_date,
     makeCountyFromDescription,
     filterDataToRecent,
-    getOldestMomentInData
+    getOldestMomentInData,
+    useStickyState,
 }

--- a/website/src/graphs/GraphDailyGeneric.js
+++ b/website/src/graphs/GraphDailyGeneric.js
@@ -3,7 +3,7 @@ import {
     ResponsiveContainer, YAxis, XAxis, Tooltip,
     CartesianGrid, Legend, LineChart, Line
 } from 'recharts';
-import { myShortNumber } from '../Util.js';
+import { myShortNumber, useStickyState } from '../Util.js';
 import { computeMovingAverage, sortByFullDate, mergeDataSeries } from "./DataSeries";
 import { makeStyles } from '@material-ui/core/styles';
 import { Typography } from '@material-ui/core';
@@ -124,28 +124,17 @@ const GraphDailyGenericInner = (props) => {
 }
 
 const GraphDailyGeneric = (props) => {
-    const CookieSetPreference = (state) => {
-        Cookies.set("GraphDailyPreference", state, {
-            expires: 100
-        });
-    }
-    const CookieGetPreference = () => {
-        let pref = Cookies.getJSON("GraphDailyPreference");
-        if (!pref) {
-            return {
-                showlog: false,
-                showAllData: false,
-            }
-        }
-        return pref;
-    }
-    const [state, setState] = React.useState(CookieGetPreference());
+
+    const [state, setStateSticky] = useStickyState({
+        defaultValue: {
+            showlog: false,
+            showAllData: false,
+        },
+        cookieId: "GraphDailyPreference"
+    });
+
     const classes = useStyles();
 
-    const setStateSticky = (state) => {
-        CookieSetPreference(state);
-        setState(state);
-    }
     const handleShowAllData = event => {
         let newstate = { ...state, showAllData: !state.showAllData };
         setStateSticky(newstate);

--- a/website/src/graphs/GraphDaysToDoubleOverTime.js
+++ b/website/src/graphs/GraphDaysToDoubleOverTime.js
@@ -2,15 +2,18 @@ import React from 'react';
 import { ResponsiveContainer, Tooltip, LineChart, Line, YAxis, XAxis, CartesianGrid, Legend } from 'recharts';
 import { Typography } from '@material-ui/core';
 import Grid from '@material-ui/core/Grid';
-import { myShortNumber, filterDataToRecent, getOldestMomentInData } from '../Util';
+import { myShortNumber, filterDataToRecent, getOldestMomentInData, useStickyState } from '../Util';
 import { DateRangeSlider } from "../DateRangeSlider"
 
 const moment = require("moment");
 
 const GraphDaysToDoubleOverTime = (props) => {
 
-    const [state, setState] = React.useState({
-        showPastDays: 30,
+    const [state, setState] = useStickyState({
+        defaultValue: {
+            showPastDays: 30,
+        },
+        cookieId: "DaysToDoubleOverTimeGraphPreferences"
     });
 
     const [mydata, setMydata] = React.useState(null);

--- a/website/src/graphs/GraphNewCases.js
+++ b/website/src/graphs/GraphNewCases.js
@@ -6,7 +6,7 @@ import Grid from '@material-ui/core/Grid';
 import { scaleSymlog } from 'd3-scale';
 import { datesToDays, fitExponentialTrendingLine } from './TrendFitting';
 import { mergeDataSeries, makeDataSeriesFromTotal, exportColumnFromDataSeries } from "./DataSeries";
-import { myShortNumber, filterDataToRecent, getOldestMomentInData } from '../Util';
+import { myShortNumber, filterDataToRecent, getOldestMomentInData, useStickyState } from '../Util';
 import { AntSwitch } from "./AntSwitch.js"
 import { DateRangeSlider } from "../DateRangeSlider"
 import axisScales from './GraphAxisScales'
@@ -86,33 +86,20 @@ const CustomTooltip = (props) => {
   return null;
 }
 
-const CookieSetPreference = (state) => {
-  Cookies.set("BasicGraphPreference1", state, {
-    expires: 100
-  });
-}
-
-const CookieGetPreference = () => {
-  let pref = Cookies.getJSON("BasicGraphPreference1");
-  if (!pref || !pref.verticalScale || !pref.showPastDays) {
-    return {
-      verticalScale: axisScales.linear,
-      showPastDays: 30,
-    }
-  }
-  return pref;
-}
-
+const cookieStaleWhen = (cookie) => !cookie.verticalScale || !cookie.showPastDays
 
 const BasicGraph = (props) => {
   const classes = useStyles()
   let data = props.USData;
   const column = props.column;
-  const [state, setState] = React.useState(CookieGetPreference());
-  const setStateSticky = (state) => {
-    CookieSetPreference(state);
-    setState(state);
-  }
+  const [state, setStateSticky] = useStickyState({
+      defaultValue: {
+          verticalScale: axisScales.linear,
+          showPastDays: 30,
+      },
+      cookieId: "BasicGraphPreference1",
+      isCookieStale: cookieStaleWhen
+  });
   const handleLogScaleToggle = (event, newScale) => {
     setStateSticky({
       ...state,

--- a/website/src/graphs/GraphRecoveryAndDeath.js
+++ b/website/src/graphs/GraphRecoveryAndDeath.js
@@ -3,7 +3,7 @@ import { ResponsiveContainer, Tooltip, LineChart, Line, YAxis, XAxis, CartesianG
 import { Typography } from '@material-ui/core';
 import Grid from '@material-ui/core/Grid';
 import { scaleSymlog } from 'd3-scale';
-import { myShortNumber, filterDataToRecent, getOldestMomentInData } from '../Util';
+import { myShortNumber, filterDataToRecent, getOldestMomentInData, useStickyState } from '../Util';
 import { AntSwitch } from "./AntSwitch.js"
 import { State } from '../UnitedStates';
 import { DateRangeSlider } from "../DateRangeSlider"
@@ -14,9 +14,12 @@ const moment = require("moment");
 const scale = scaleSymlog().domain([0, 'dataMax']);
 
 const BasicGraphRecoveryAndDeath = (props) => {
-    const [state, setState] = React.useState({
-        verticalScale: axisScales.linear,
-        showPastDays: 30,
+    const [state, setState] = useStickyState({
+        defaultValue: {
+            verticalScale: axisScales.linear,
+            showPastDays: 30,
+        },
+        cookieId: "RecoveryAndDeathGraphPreferences"
     });
 
     const [USData, setUSdata] = React.useState(null);


### PR DESCRIPTION
Question: should all the graphs share the same cookie for the `showPastDays` param?

I think not, since it would lead to an odd behavior whereby sliding one slider would result in another slider being in a different position upon component re-mount. 

That said, I think it's worth considering because this would mean default behavior has users comparing apples-to-apples. 

Will close #109 