### PR TITLE
Add slider to map for confirmed cases

### DIFF
--- a/website/src/DateRangeSlider.js
+++ b/website/src/DateRangeSlider.js
@@ -27,9 +27,12 @@ const DateRangeSlider = (props) => {
     const startDate = moment(props.startDate);
     const currentDate = moment(props.currentDate);
     const daysBetween = currentDate.diff(startDate, 'days');
-    let defaultValue = props.defaultValue ? (daysBetween - props.defaultValue) : daysBetween - 30
+
+    let defaultValue = props.defaultValue !== undefined ? (daysBetween - props.defaultValue) : daysBetween - 30
     defaultValue = (defaultValue > -1) ? defaultValue : 0;
-    const maxValue = (daysBetween > 13) ? daysBetween - 14 : daysBetween;
+
+    const defaultMaxValue = (daysBetween > 13) ? daysBetween - 14 : daysBetween;
+    const maxValue = props.minOffset !== undefined ? daysBetween - props.minOffset : defaultMaxValue
 
     const [valueState, setValueState] = React.useState(defaultValue)
 

--- a/website/src/MapUS.js
+++ b/website/src/MapUS.js
@@ -4,12 +4,25 @@ import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
 import * as d3 from "d3-scale";
 
 import { AntSwitch } from "./graphs/AntSwitch"
-import { Grid } from '@material-ui/core';
+import { Grid, makeStyles } from '@material-ui/core';
 import { withRouter } from 'react-router-dom'
 import { NO_DATA_COLOR, MapCountyGeneric } from "./MapCountyGeneric"
 import { MapStateGeneric } from "./MapStateGeneric";
 import { Country } from "./UnitedStates";
 import { CountryContext } from "./CountryContext"
+import { DateRangeSlider } from "./DateRangeSlider"
+import { useStickyState } from "./Util"
+
+const moment = require("moment");
+
+const useStyles = makeStyles(theme => ({
+  gridPadding: {
+    minWidth: '1vw'
+  },
+  container: {
+    minHeight: 45
+  }
+}));
 
 const logColors = () => {
   return d3.scaleLog().clamp(true);
@@ -71,6 +84,8 @@ const CountyNavButtons = withRouter((props) => {
 });
 
 const MapUS = withRouter((props) => {
+  const classes = useStyles()
+
   const source = props.source;
   const [perCapita, setPerCapita] = React.useState(true);
   const [selectedCounty, setSelectedCounty] = React.useState(null);
@@ -121,22 +136,59 @@ const MapUS = withRouter((props) => {
     )}
   </ToggleButtonGroup>;
 
+  const [dataFetched, setDataFetched] = React.useState(null);
+  const [showPastDays, setShowPastDays] = React.useState(0)
+
+  const getDate = (isDataFetched, showPastNumDays) => {
+    return isDataFetched ? moment().subtract(showPastNumDays, 'days').format('MM/DD/YYYY') : null
+  }
+
+  const country = React.useContext(CountryContext);
+
+  React.useEffect(() => {
+    if (country) {
+      country.fetchAllUSCountyData().then(() => {
+        setDataFetched(true);
+      });
+    }
+  }, [country]);
+
   return <div>
     {buttonGroup}
-    <Grid container alignItems="center">
+    <Grid container alignItems="center" spacing={1} className={classes.container}>
       <Grid item>
         <AntSwitch checked={perCapita} onClick={() => { setPerCapita(!perCapita) }} />
       </Grid>
       <Grid item>
         Per Capita
-            </Grid>
+      </Grid>
+      <Grid className={classes.gridPadding}></Grid>
+      {dataFetched && desired === "confirmed" ?
+        <Grid item>
+          {getDate(dataFetched, showPastDays)}:
+        </Grid>
+      : <></>}
+      {dataFetched && desired === "confirmed" ?
+        <Grid item xs sm={3}>
+          <DateRangeSlider
+            currentDate={moment()}
+            startDate={moment({ year: 2020, month: 3, day: 1 })}
+            minOffset={0}
+            defaultValue={showPastDays}
+            valueChanged={(val) => {
+              setShowPastDays(val);
+            }}
+          />
+        </Grid>
+      : <></>}
+      <Grid item sm></Grid>
+      <Grid className={classes.gridPadding}></Grid>
     </Grid>
-    <ChosenMap {...props} source={source} perCapita={perCapita} selectionCallback={setSelectedCounty} />
+    <ChosenMap {...props} date={getDate(dataFetched, showPastDays)} source={source} perCapita={perCapita} selectionCallback={setSelectedCounty} />
     {
       selectedCounty &&
       <CountyNavButtons county={selectedCounty} />
     }
-
   </div >
 });
 
@@ -168,20 +220,12 @@ const MapDaysToDouble = React.memo((props) => {
 });
 
 const MapUSConfirmed = React.memo((props) => {
-  const [date, setDate] = React.useState(null);
-  const country = React.useContext(CountryContext);
-  React.useEffect(() => {
-    // country.fetchAllUSCountyData().then(() => {
-    //   // active slider here 
-    //   setDate("04/01/2020");
-    // });
-  }, [country]);
 
   return (
     <MapCountyGeneric
       {...props}
       getCountyDataPoint={(county) => {
-        return county.getConfirmedByDate(date);
+        return county.getConfirmedByDate(props.date);
       }}
       colorFunction={(data) => {
         return ColorScale.confirmed(data);
@@ -190,7 +234,7 @@ const MapUSConfirmed = React.memo((props) => {
         return ColorScale.confirmedPerMillion(data);
       }}
       toolip={county => {
-        let confirmed = county.getConfirmedByDate(date);
+        let confirmed = county.getConfirmedByDate(props.date);
         return `${county.name}, Confirmed: ${confirmed}, \n` +
           `Confirm/Mil: ${(confirmed / county.population() * 1000000).toFixed(0)}`
       }}


### PR DESCRIPTION
Two notes:

1. Should we use sticky state? Pro: Users can navigate between their state and US to see how their state compared to the US on a given day. Con: Next time they visit the site, they'll be looking at a map that's `x` days old.
2. How do you like the current method of displaying the current map's date?

Closes #102 (I think)