### PR TITLE
Add a nearby view to the world stuff

### DIFF
--- a/website/src/components/tables/DivisionTable.js
+++ b/website/src/components/tables/DivisionTable.js
@@ -15,10 +15,7 @@ import {WorldContext} from '../../WorldContext';
 export const DivisionTable = (props) => {
   const world = useContext(WorldContext);
   const children =
-      world.get(
-              props.id ? props.parent.child(props.id) : props.parent,
-              ChildrenComponent)
-          .children();
+      world.get(props.parent, ChildrenComponent).children();
 
   const columns = [
     {key: 'name', label: 'Name', defaultDirection: 'asc'},
@@ -29,8 +26,22 @@ export const DivisionTable = (props) => {
   ];
   const defaultSortColumn = columns[1];
 
+  let picked;
+  if (props.pickLowest) {
+    const {count, quantifier} = props.pickLowest;
+    picked =
+        children.sort((a, b) => quantifier(a) - quantifier(b))
+            .slice(0, count);
+  } else {
+    picked = children;
+  }
+
   const rows = [];
-  for (const child of children) {
+  for (const child of picked) {
+    if (props.filter && !props.filter(child)) {
+      continue;
+    }
+
     const [name, basic, population] =
         world.getMultiple(child, [NameComponent, BasicDataComponent, PopulationComponent]);
     if (!name || !basic) {
@@ -76,8 +87,12 @@ export const DivisionTable = (props) => {
 };
 
 DivisionTable.propTypes = {
-  id: PropTypes.string.isRequired,
-  plural: PropTypes.string.isRequired,
   parent: PropTypes.instanceOf(Path).isRequired,
+  plural: PropTypes.string.isRequired,
   className: PropTypes.string,
+  filter: PropTypes.func,
+  pickLowest: PropTypes.exact({
+    count: PropTypes.number.isRequired,
+    quantifier: PropTypes.func.isRequired,
+  }),
 };

--- a/website/src/models/Earth.js
+++ b/website/src/models/Earth.js
@@ -2,6 +2,7 @@ import {BasicDataComponent} from './BasicDataComponent';
 import {ChildrenComponent} from './ChildrenComponent';
 import {DataSeries} from './DataSeries';
 import {DivisionTypesComponent} from './DivisionTypesComponent';
+import {GeographyComponent} from './GeographyComponent';
 import {NameComponent} from './NameComponent';
 import {PopulationComponent} from './PopulationComponent';
 import {World} from './World';
@@ -104,15 +105,21 @@ class BasicEarthSource {
   }
 
   basicComponentsFor_(data) {
-    return [
+    const components = [
       new NameComponent(data['name']),
       new BasicDataComponent(
           DataSeries.fromFormattedDates("Confirmed", data['Confirmed']),
           DataSeries.fromFormattedDates("Active", data['Active']),
           DataSeries.fromFormattedDates("Recovered", data['Recovered']),
           DataSeries.fromFormattedDates("Deaths", data['Deaths'])),
-      new PopulationComponent(data['population']),
     ];
+    if (data['latitude'] && data['longitude']) {
+      components.push(new GeographyComponent(data['latitude'], data['longitude']));
+    }
+    if (data['population']) {
+      components.push(new PopulationComponent(data['population']));
+    }
+    return components;
   }
 }
 

--- a/website/src/models/GeographyComponent.js
+++ b/website/src/models/GeographyComponent.js
@@ -1,0 +1,16 @@
+const geolib = require('geolib');
+
+export class GeographyComponent {
+
+  constructor(latitude, longitude) {
+    this.position_ = {latitude, longitude};
+  }
+
+  distance(other) {
+    return geolib.getDistance(this.position_, other.position_);
+  }
+
+  position() {
+    return this.position_;
+  }
+}

--- a/website/src/models/Path.js
+++ b/website/src/models/Path.js
@@ -21,12 +21,20 @@ export class Path {
     return new Path(this.components.concat(name));
   }
 
+  equals(other) {
+    return this.string() === other.string();
+  }
+
   parent() {
     if (this.level() > 0) {
       return new Path(this.components.slice(0, this.components.length - 1));
     } else {
       return undefined;
     }
+  }
+
+  lastComponent() {
+    return this.components[this.components.length - 1];
   }
 
   level() {

--- a/website/src/models/World.js
+++ b/website/src/models/World.js
@@ -30,6 +30,17 @@ export class World {
     }
   }
 
+  has(path, componentType) {
+    this.ensure_(path);
+
+    const asStr = path.string();
+    if (!this.componentsByPath.has(asStr)) {
+      return false;
+    } else {
+      return !!this.componentsByPath.get(asStr).get(componentType);
+    }
+  }
+
   set(path, component) {
     const asStr = path.string();
     if (!this.componentsByPath.has(asStr)) {


### PR DESCRIPTION
From our previously discussed tasks:

P0 - data generation automated and cleaned up. **is this done? not sure how it works**
P0 - US bridging code (done)
P1 (P0 for ads) - geoIP --> country **not done**
P2 - search bar **not done**

P0 - Fix log scale (done)
P0 - sort the data tables (done)
P0(?) - pull in the comments **not done**
P0 - pull in the footer (done)
P0 - figure out if we really want the thing to say "Earth", it feels dorky but I didn't know what else to put. "World" doesn't sound right to me. (I guess this is done)
P? pull in the social media icons (done)
P? add per capita in the table (done)
P? adds days 2x to the table (done)
P? decide if we want to show these numbers, and if so how (we don't want to because we don't have the data)
![](https://user-images.githubusercontent.com/115766/80943007-0c0f5480-8d9b-11ea-978a-6da6d3ef6c76.png)

Can you think of more? I guess:
P0 - determine the canonical graphs to show **not done**
P0 - accept that we aren't launching with maps? Unless you want to figure out the geography stuff with RSM, I'd rather not