### PR TITLE
Stale cookie case threw an uncaught error

### DIFF
--- a/website/src/GeoLocation.js
+++ b/website/src/GeoLocation.js
@@ -38,7 +38,7 @@ export async function fetchApproximatePoliticalLocation() {
   if (saved) {
     return saved;
   }
-  
+
   const location =  await fetchLocationUsingMethods([
     () => fetchApproxIPLocationIPDataCo(firebaseConfig.ipdataco_key),
     () => fetchApproxIPLocationIPDataCo(firebaseConfig.ipdataco_key2),
@@ -173,7 +173,7 @@ function getLocationFromCookie() {
     logger.logEvent("LocationFoundInCookie", cookie);
     return cookie;
   } else {
-    throw new Error("No cookie or invalid one");
+    return null;
   }
 }
 


### PR DESCRIPTION
Error thrown and not caught. Replaced with null return. Left user stuck on landing page.

To repro:
Open new incognito. Make sure cookies are cleared.
Go to the landing page.
Observe that you're not taken to a graph